### PR TITLE
Add tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,16 @@
+name: Syntax Tests
+
+on: [push, pull_request]
+
+jobs:
+  st4_syntax_tests:
+    name: Run ST4 Syntax Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: SublimeText/syntax-test-action@v2
+        with:
+          build: 4152
+          default_packages: v4152
+          package_name: Ngx HTML

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ jobs:
     name: Run ST4 Syntax Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: SublimeText/syntax-test-action@v2
         with:

--- a/NgxHTML.sublime-syntax
+++ b/NgxHTML.sublime-syntax
@@ -93,26 +93,27 @@ contexts:
       scope: keyword.control.control-flow.html
       captures:
         1: punctuation.definition.keyword.html
-    - match: \(
-      scope: punctuation.section.group.begin.html
       push:
-        - meta_scope: meta.group.html
-        - match: \b(async)\b
-          scope: keyword.control.html
-        - match: \b(track|of|prefetch on|on|prefetch when|when|as)\b
-          scope: keyword.operator.word.html
-        - match: \b(minimum|after)\b(\?)
-          captures:
-            1: keyword.operator.word.html
-            2: keyword.control.question.html
-        - match: \)
-          scope: punctuation.section.group.end.html
-          pop: 1
-    - match: \{
-      scope: punctuation.section.block.begin.html
-      push:
-        - meta_scope: meta.block.html
-        - include: main
-        - match: \}
-          scope: punctuation.section.block.end.html
-          pop: 1
+        - match: \{
+          scope: punctuation.section.block.begin.html
+          push:
+            - meta_scope: meta.block.html
+            - include: main
+            - match: \}
+              scope: punctuation.section.block.end.html
+              pop: 2
+        - match: \(
+          scope: punctuation.section.group.begin.html
+          push:
+            - meta_scope: meta.group.html
+            - match: \b(async)\b
+              scope: keyword.control.html
+            - match: \b(track|of|prefetch on|on|prefetch when|when|as)\b
+              scope: keyword.operator.word.html
+            - match: \b(minimum|after)\b(\?)
+              captures:
+                1: keyword.operator.word.html
+                2: keyword.control.question.html
+            - match: \)
+              scope: punctuation.section.group.end.html
+              pop: 1

--- a/tests/syntax_test_control_flow.component.html
+++ b/tests/syntax_test_control_flow.component.html
@@ -1,10 +1,22 @@
 <!-- SYNTAX TEST "NgxHTML.sublime-syntax" -->
 
 @if (loggedIn) {
+<!-- <- punctuation.definition.keyword.html -->
+ <!-- <- keyword.control.control-flow.html -->
+  <!-- <- keyword.control.control-flow.html -->
+          <!-- ^ punctuation.section.block.begin.html -->
   The user is logged in
 } @else {
+<!-- <- punctuation.section.block.end.html -->
+   <!-- ^ punctuation.section.block.begin.html -->
+  <!-- <- punctuation.definition.keyword.html -->
+   <!-- <- keyword.control.control-flow.html -->
+    <!-- <- keyword.control.control-flow.html -->
+     <!-- <- keyword.control.control-flow.html -->
+      <!-- <- keyword.control.control-flow.html -->
   The user is not logged in
 }
+<!-- <- punctuation.section.block.end.html -->
 
 @if (a > b) {
   {{ a }} is greater than {{ b }}

--- a/tests/syntax_test_control_flow.component.html
+++ b/tests/syntax_test_control_flow.component.html
@@ -1,0 +1,92 @@
+<!-- Angular v17 Blog examples -->
+
+@if (loggedIn) {
+  The user is logged in
+} @else {
+  The user is not logged in
+}
+
+@switch (accessLevel) {
+  @case ('admin') {
+    <admin-dashboard />
+  }
+  @case ('moderator') {
+    <moderator-dashboard />
+  }
+  @default {
+    <user-dashboard />
+  }
+}
+
+@for (user of users; track user.id) {
+  {{ user.name }}
+} @empty {
+  Empty list of users
+}
+
+@defer {
+  <comment-list />
+}
+
+@defer (on viewport) {
+  <comment-list />
+} @placeholder {
+  <!-- A placeholder content to show until the comments load -->
+  <img src="comments-placeholder.png" />
+}
+
+@defer (on viewport) {
+  <comment-list />
+} @loading {
+  Loading…
+} @error {
+  Loading failed :(
+} @placeholder {
+  <img src="comments-placeholder.png" />
+}
+
+@defer (on viewport; prefetch on idle) {
+  <comment-list />
+}
+
+<!-- Examples Provided by @thecodechef -->
+
+@for (item of items) {
+  <a [href]="item.link">{{ item.title }}</a>
+}
+
+@for (item of items) {
+  <a [href]="item.link">{{ item.title }}</a>
+} @empty {
+  <p>No Items</p>
+}
+
+@if (users$ | async; as users) {
+  {{ users.length }}
+}
+
+@switch (condition) {
+  @case (caseA) {
+    Case A.
+  }
+  @case (caseB) {
+    Case B.
+  }
+  @default {
+    Default case.
+  }
+}
+
+@defer (on <trigger>; when <condition>; prefetch on <trigger>; prefetch when <condition>) {
+  <!-- deferred template fragment -->
+  <calendar-cmp />
+} @placeholder (minimum? <duration>) {
+  <!-- placeholder template fragment -->
+  <p>Placeholder</p>
+} @loading (minimum? <duration>; after? <duration>) {
+  <!-- loading template fragment -->
+  <img alt="loading image" src="loading.gif" />
+} @error {
+  <!-- error template fragment -->
+  <p>An loading error occured</p>
+}

--- a/tests/syntax_test_control_flow.component.html
+++ b/tests/syntax_test_control_flow.component.html
@@ -19,8 +19,11 @@
 <!-- <- punctuation.section.block.end.html -->
 
 @if (a > b) {
-<!-- <- punctuation.section.block.end.html -->
   {{ a }} is greater than {{ b }}
+  <!-- <- punctuation.section.interpolation.begin.ngx.html -->
+   <!-- <- punctuation.section.interpolation.begin.ngx.html -->
+       <!-- <- punctuation.section.interpolation.end.ngx.html -->
+        <!-- <- punctuation.section.interpolation.end.ngx.html -->
 }
 
 @if (a > b) {
@@ -34,6 +37,10 @@
 @switch (accessLevel) {
   @case ('admin') {
     <admin-dashboard />
+<!-- ^^^^^^^^^^^^^^^ entity.name.tag.other.html -->
+    <!-- <- punctuation.definition.tag.begin.html -->
+                     <!-- <- punctuation.definition.tag.end.html -->
+                      <!-- <- punctuation.definition.tag.end.html -->
   }
   @case ('moderator') {
     <moderator-dashboard />

--- a/tests/syntax_test_control_flow.component.html
+++ b/tests/syntax_test_control_flow.component.html
@@ -1,3 +1,5 @@
+<!-- SYNTAX TEST "NgxHTML.sublime-syntax" -->
+
 <!-- Angular v17 Blog examples -->
 
 @if (loggedIn) {

--- a/tests/syntax_test_control_flow.component.html
+++ b/tests/syntax_test_control_flow.component.html
@@ -19,6 +19,7 @@
 <!-- <- punctuation.section.block.end.html -->
 
 @if (a > b) {
+<!-- <- punctuation.section.block.end.html -->
   {{ a }} is greater than {{ b }}
 }
 

--- a/tests/syntax_test_control_flow.component.html
+++ b/tests/syntax_test_control_flow.component.html
@@ -1,11 +1,21 @@
 <!-- SYNTAX TEST "NgxHTML.sublime-syntax" -->
 
-<!-- Angular v17 Blog examples -->
-
 @if (loggedIn) {
   The user is logged in
 } @else {
   The user is not logged in
+}
+
+@if (a > b) {
+  {{ a }} is greater than {{ b }}
+}
+
+@if (a > b) {
+  {{ a }} is greater than {{ b }}
+} @else if (b > a) {
+  {{ a }} is less than {{ b }}
+} @else {
+  {{ a }} is equal to {{ b }}
 }
 
 @switch (accessLevel) {
@@ -51,7 +61,9 @@
   <comment-list />
 }
 
-<!-- Examples Provided by @thecodechef -->
+@for (item of items; track item.id; let idx = $index, e = $even) {
+  Item #{{ idx }}: {{ item.name }}
+}
 
 @for (item of items) {
   <a [href]="item.link">{{ item.title }}</a>
@@ -63,8 +75,18 @@
   <p>No Items</p>
 }
 
+@for (item of items; track item.name) {
+  <li>{{ item.name }}</li>
+} @empty {
+  <li>There are no items.</li>
+}
+
 @if (users$ | async; as users) {
   {{ users.length }}
+}
+
+@for (item of items; track item.id) {
+  {{ item.name }}
 }
 
 @switch (condition) {


### PR DESCRIPTION
@thecodechef 

The current implementation is a little sensitive to braces. The `:(` in the screenshot broke the syntax highlighting. Do we have an easy way to scope it to right after an `@block` match?

![image](https://github.com/princemaple/ngx-html-syntax/assets/1329716/a3ef866e-4a7d-44cc-80c9-01a03e777658)
