### PR TITLE
Fix interpolation scope

### DIFF
--- a/NgxHTML.sublime-syntax
+++ b/NgxHTML.sublime-syntax
@@ -19,12 +19,12 @@ contexts:
 
   interpolation:
     - match: '{{'
-      scope: punctuation.section.interpolation.begin.ngx.html
+      scope: meta.interpolation.ngx.html punctuation.section.interpolation.begin.ngx.html
       embed: scope:source.js
-      embed_scope: meta.interpolation.ngx.html
+      embed_scope: meta.interpolation.ngx.html source.js.embedded.ngx.html
       escape: '}}'
       escape_captures:
-        0: punctuation.section.interpolation.end.ngx.html
+        0: meta.interpolation.ngx.html punctuation.section.interpolation.end.ngx.html
 
   tag-attributes:
     - meta_prepend: true

--- a/tests/syntax_test_control_flow.component.html
+++ b/tests/syntax_test_control_flow.component.html
@@ -24,6 +24,9 @@
    <!-- <- punctuation.section.interpolation.begin.ngx.html -->
        <!-- <- punctuation.section.interpolation.end.ngx.html -->
         <!-- <- punctuation.section.interpolation.end.ngx.html -->
+  <!--                    ^^ meta.interpolation.ngx.html punctuation.section.interpolation.begin.ngx.html - source.js -->
+  <!--                      ^^^ meta.interpolation.ngx.html source.js.embedded.ngx.html -->
+  <!--                         ^^ meta.interpolation.ngx.html punctuation.section.interpolation.end.ngx.html - source.js -->
 }
 
 @if (a > b) {


### PR DESCRIPTION
This commit...

1. applies `meta.interpolation` to `{{` and `}}` interpolation punctuation.
2. adds `source.js.embedded` to interpolation content, so java script specific settings and completions apply.