### PR TITLE
Fix meta.embedded vs. meta.interpolation

### DIFF
--- a/Embeddings/CSS (for Ngx).sublime-syntax
+++ b/Embeddings/CSS (for Ngx).sublime-syntax
@@ -1,0 +1,42 @@
+%YAML 1.2
+---
+# A special syntax definition to drive double quoted inline style attributes
+# with {...} interpolation support
+scope: source.css.embedded.ngx
+version: 2
+hidden: true
+
+extends: Packages/CSS/CSS.sublime-syntax
+
+variables:
+  ident_start: (?:{{nmstart}}|{{)
+
+contexts:
+
+  prototype:
+    - meta_prepend: true
+    - include: NgxHTML.sublime-syntax#ng-interpolations
+
+  string-content:
+    - meta_prepend: true
+    - include: NgxHTML.sublime-syntax#ng-string-interpolations
+
+  at-keyframe-block-body:
+    # required until ST4174 (PR #3820)
+    - meta_prepend: true
+    - meta_include_prototype: false
+
+  at-layer-name-list:
+    # required until ST4174 (PR #3820)
+    - meta_prepend: true
+    - meta_include_prototype: false
+
+  property-list-body:
+    # required until ST4174 (PR #3820)
+    - meta_prepend: true
+    - meta_include_prototype: false
+
+  stylesheet-block-body:
+    # required until ST4174 (PR #3831)
+    - meta_prepend: true
+    - meta_include_prototype: false

--- a/NgxHTML.sublime-syntax
+++ b/NgxHTML.sublime-syntax
@@ -40,6 +40,23 @@ contexts:
     - meta_prepend: true
     - include: ng-string-interpolations
 
+###[ HTML STYLE TAG ]##########################################################
+
+  style-css-content:
+    - meta_include_prototype: false
+    - match: '{{style_content_begin}}'
+      captures:
+        1: comment.block.html punctuation.definition.comment.begin.html
+      pop: 1  # make sure to match only once
+      embed: scope:source.css.embedded.ngx
+      embed_scope: source.css.embedded.html
+      escape: '{{style_content_end}}'
+      escape_captures:
+        1: source.css.embedded.html
+        2: comment.block.html punctuation.definition.comment.end.html
+        3: source.css.embedded.html
+        4: comment.block.html punctuation.definition.comment.end.html
+
 ###[ HTML STYLE ATTRIBUTES ]###################################################
 
   tag-style-attribute-assignment:

--- a/NgxHTML.sublime-syntax
+++ b/NgxHTML.sublime-syntax
@@ -177,7 +177,9 @@ contexts:
 
   ng-declarations:
     - match: (@)let{{ident_break}}
-      scope: meta.let.ngx keyword.declaration.variable.ngx
+      scope:
+        meta.embedded.statement.ngx.html source.ngx.embedded.html
+        meta.let.ngx keyword.declaration.variable.ngx
       captures:
         1: punctuation.definition.keyword.ngx
       push:
@@ -191,15 +193,21 @@ contexts:
     - include: else-pop
 
   ng-let-assignment:
-    - meta_content_scope: meta.let.identifier.ngx
+    - meta_content_scope:
+        meta.embedded.statement.ngx.html source.ngx.embedded.html
+        meta.let.identifier.ngx
     - match: =
-      scope: meta.let.ngx keyword.operator.assignment.ngx
+      scope:
+        meta.embedded.statement.ngx.html source.ngx.embedded.html
+        meta.let.ngx keyword.operator.assignment.ngx
       set: ng-let-value
     - include: else-pop
 
   ng-let-value:
     - meta_include_prototype: false
-    - meta_content_scope: meta.let.value.ngx
+    - meta_content_scope:
+        meta.embedded.statement.ngx.html source.ngx.embedded.html
+        meta.let.value.ngx
     - match: ';'
       scope: punctuation.terminator.expression.ngx
       pop: 1
@@ -211,39 +219,51 @@ contexts:
     # conditionals
     # https://angular.dev/guide/templates/control-flow#conditionally-display-content-with-if-else-if-and-else
     - match: (@)if{{ident_break}}
-      scope: keyword.control.conditional.if.ngx
+      scope:
+        meta.embedded.statement.ngx.html source.ngx.embedded.html
+        keyword.control.conditional.if.ngx
       captures:
         1: punctuation.definition.keyword.ngx
       push:
         - ng-block
         - ng-conditional-group
     - match: (@)else\s+if{{ident_break}}
-      scope: keyword.control.conditional.elseif.ngx
+      scope:
+        meta.embedded.statement.ngx.html source.ngx.embedded.html
+        keyword.control.conditional.elseif.ngx
       captures:
         1: punctuation.definition.keyword.ngx
       push:
         - ng-block
         - ng-conditional-group
     - match: (@)else{{ident_break}}
-      scope: keyword.control.conditional.else.ngx
+      scope:
+        meta.embedded.statement.ngx.html source.ngx.embedded.html
+        keyword.control.conditional.else.ngx
       captures:
         1: punctuation.definition.keyword.ngx
       push: ng-block
     # https://angular.dev/guide/templates/control-flow#conditionally-display-content-with-the-switch-block
     - match: (@)case{{ident_break}}
-      scope: keyword.control.conditional.case.ngx
+      scope:
+        meta.embedded.statement.ngx.html source.ngx.embedded.html
+        keyword.control.conditional.case.ngx
       captures:
         1: punctuation.definition.keyword.ngx
       push:
         - ng-block
         - ng-conditional-group
     - match: (@)default{{ident_break}}
-      scope: keyword.control.conditional.case.ngx
+      scope:
+        meta.embedded.statement.ngx.html source.ngx.embedded.html
+        keyword.control.conditional.case.ngx
       captures:
         1: punctuation.definition.keyword.ngx
       push: ng-block
     - match: (@)switch{{ident_break}}
-      scope: keyword.control.conditional.switch.ngx
+      scope:
+        meta.embedded.statement.ngx.html source.ngx.embedded.html
+        keyword.control.conditional.switch.ngx
       captures:
         1: punctuation.definition.keyword.ngx
       push:
@@ -251,20 +271,26 @@ contexts:
         - ng-conditional-group
     # https://angular.dev/guide/templates/control-flow#providing-a-fallback-for-for-blocks-with-the-empty-block
     - match: (@)for{{ident_break}}
-      scope: keyword.control.loop.for.ngx
+      scope:
+        meta.embedded.statement.ngx.html source.ngx.embedded.html
+        keyword.control.loop.for.ngx
       captures:
         1: punctuation.definition.keyword.ngx
       push:
         - ng-block
         - ng-for-group
     - match: (@)empty{{ident_break}}
-      scope: keyword.control.loop.else.ngx
+      scope:
+        meta.embedded.statement.ngx.html source.ngx.embedded.html
+        keyword.control.loop.else.ngx
       captures:
         1: punctuation.definition.keyword.ngx
       push: ng-block
     # https://angular.dev/guide/templates/defer
     - match: (@)(?:defer|error|loading|placeholder){{ident_break}}
-      scope: keyword.control.flow.ngx
+      scope:
+        meta.embedded.statement.ngx.html source.ngx.embedded.html
+        keyword.control.flow.ngx
       captures:
         1: punctuation.definition.keyword.ngx
       push:
@@ -273,6 +299,7 @@ contexts:
 
   ng-block:
     - meta_include_prototype: false
+    - meta_content_scope: meta.embedded.statement.ngx.html source.ngx.embedded.html
     - match: \{
       scope: punctuation.section.block.begin.ngx
       set: ng-block-body

--- a/NgxHTML.sublime-syntax
+++ b/NgxHTML.sublime-syntax
@@ -14,6 +14,14 @@ contexts:
 
 ###[ HTML CUSTOMIZATIONS ]#####################################################
 
+  cdata-content:
+    - meta_prepend: true
+    - include: ng-string-interpolations
+
+  strings-common-content:
+    - meta_prepend: true
+    - include: ng-string-interpolations
+
   tag:
     - meta_prepend: true
     - include: ng-declarations
@@ -23,6 +31,44 @@ contexts:
   tag-attributes:
     - meta_prepend: true
     - include: ng-directives
+
+  tag-generic-attribute-name:
+    - meta_prepend: true
+    - include: ng-interpolations
+
+  tag-attribute-value-content:
+    - meta_prepend: true
+    - include: ng-string-interpolations
+
+###[ HTML STYLE ATTRIBUTES ]###################################################
+
+  tag-style-attribute-assignment:
+    - meta_include_prototype: false
+    - match: =
+      scope: punctuation.separator.key-value.html
+      set:
+        - immediately-pop  # workaround https://github.com/sublimehq/sublime_text/issues/4069
+        - tag-style-attribute-value
+    - include: else-pop
+
+  tag-style-attribute-value:
+    - match: \"
+      scope: meta.string.html string.quoted.double.html punctuation.definition.string.begin.html
+      embed: scope:source.css.embedded.ngx#rule-list-body
+      embed_scope: meta.string.html source.css.embedded.html
+      escape: \"
+      escape_captures:
+        0: meta.string.html string.quoted.double.html punctuation.definition.string.end.html
+      pop: 1
+    - match: \'
+      scope: meta.string.html string.quoted.single.html punctuation.definition.string.begin.html
+      embed: scope:source.css.embedded.ngx#rule-list-body
+      embed_scope: meta.string.html source.css.embedded.html
+      escape: \'
+      escape_captures:
+        0: meta.string.html string.quoted.single.html punctuation.definition.string.end.html
+      pop: 1
+    - include: else-pop
 
 ###[ ANGULAR DIRECTIVES ]######################################################
 
@@ -294,6 +340,17 @@ contexts:
       scope: keyword.operator.iteration.ngx
 
 ###[ ANGULAR INTERPOLATIONS ]##################################################
+
+  ng-string-interpolations:
+    - match: '{{'
+      scope: meta.embedded.expression.ngx.html punctuation.section.embedded.begin.ngx.html
+      push: ng-string-interpolation-body
+
+  ng-string-interpolation-body:
+    - clear_scopes: 1
+    - meta_include_prototype: false
+    - meta_content_scope: meta.embedded.expression.ngx.html source.ngx.embedded.html
+    - include: ng-interpolation-body
 
   ng-interpolations:
     - match: '{{'

--- a/NgxHTML.sublime-syntax
+++ b/NgxHTML.sublime-syntax
@@ -85,7 +85,7 @@ contexts:
     - match: \"
       scope: meta.string.ngx string.quoted.double.ngx punctuation.definition.string.begin.ngx
       embed: ng-directive-expressions
-      embed_scope: meta.directive.value.ngx meta.string.ngx meta.interpolation.ngx source.ngx.embedded.html
+      embed_scope: meta.directive.value.ngx meta.string.ngx meta.embedded.expression.ngx source.ngx.embedded.html
       escape: \"
       escape_captures:
         0: meta.string.ngx string.quoted.double.ngx punctuation.definition.string.end.ngx
@@ -93,7 +93,7 @@ contexts:
     - match: \'
       scope: meta.string.ngx string.quoted.single.ngx punctuation.definition.string.begin.ngx
       embed: ng-directive-expressions
-      embed_scope: meta.directive.value.ngx meta.string.ngx meta.interpolation.ngx source.ngx.embedded.html
+      embed_scope: meta.directive.value.ngx meta.string.ngx meta.embedded.expression.ngx source.ngx.embedded.html
       escape: \'
       escape_captures:
         0: meta.string.ngx string.quoted.single.ngx punctuation.definition.string.end.ngx
@@ -297,14 +297,14 @@ contexts:
 
   ng-interpolations:
     - match: '{{'
-      scope: meta.embedded.ngx.html punctuation.section.embedded.begin.ngx.html
+      scope: meta.embedded.expression.ngx.html punctuation.section.embedded.begin.ngx.html
       push: ng-interpolation-body
 
   ng-interpolation-body:
     - meta_include_prototype: false
-    - meta_content_scope: meta.embedded.ngx.html source.ngx.embedded.html
+    - meta_content_scope: meta.embedded.expression.ngx.html source.ngx.embedded.html
     - match: '}}'
-      scope: meta.embedded.ngx.html punctuation.section.embedded.end.ngx.html
+      scope: meta.embedded.expression.ngx.html punctuation.section.embedded.end.ngx.html
       pop: 1
     - include: ng-expressions
 

--- a/NgxHTML.sublime-syntax
+++ b/NgxHTML.sublime-syntax
@@ -14,6 +14,10 @@ contexts:
 
 ###[ HTML CUSTOMIZATIONS ]#####################################################
 
+  main:
+    - meta_prepend: true
+    - meta_scope: meta.template.ngx
+
   cdata-content:
     - meta_prepend: true
     - include: ng-string-interpolations

--- a/tests/syntax_test_scopes.component.html
+++ b/tests/syntax_test_scopes.component.html
@@ -6,6 +6,8 @@
  -->
 
 @let name = user.name;
+<!-- <- meta.embedded.statement.ngx.html source.ngx.embedded.html meta.let.ngx keyword.declaration.variable.ngx punctuation.definition.keyword.ngx -->
+<!--^^^^^^^^^^^^^^^^^ meta.embedded.statement.ngx.html source.ngx.embedded.html -->
 <!--^^^^^^ meta.let.identifier.ngx -->
 <!-- ^^^^ variable.other.readwrite.ngx -->
 <!--      ^ meta.let.ngx keyword.operator.assignment.ngx -->
@@ -16,6 +18,7 @@
 <!--                 ^ punctuation.terminator.expression.ngx -->
 
 @let func = user.func();
+<!--^^^^^^^^^^^^^^^^^^^ meta.embedded.statement.ngx.html source.ngx.embedded.html -->
 <!--^^^^^^ meta.let.identifier.ngx -->
 <!-- ^^^^ variable.other.readwrite.ngx -->
 <!--      ^ meta.let.ngx keyword.operator.assignment.ngx -->
@@ -29,6 +32,7 @@
 <!--                   ^ punctuation.terminator.expression.ngx -->
 
 @let greeting = 'Hello, ' + name;
+<!--^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.statement.ngx.html source.ngx.embedded.html -->
 <!--^^^^^^^^^^ meta.let.identifier.ngx -->
 <!-- ^^^^^^^^ variable.other.readwrite.ngx -->
 <!--          ^ meta.let.ngx keyword.operator.assignment.ngx -->
@@ -41,6 +45,7 @@
 <!--                            ^ punctuation.terminator.expression.ngx -->
 
 @let data = data$ | async;
+<!--^^^^^^^^^^^^^^^^^^^^^ meta.embedded.statement.ngx.html source.ngx.embedded.html -->
 <!--^^^^^^ meta.let.identifier.ngx -->
 <!--      ^ meta.let.ngx -->
 <!--       ^^^^^^^ meta.let.value.ngx - meta.filter -->
@@ -53,6 +58,7 @@
 <!--                     ^ punctuation.terminator.expression.ngx -->
 
 @let item = var[10]['bar'];
+<!--^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.statement.ngx.html source.ngx.embedded.html -->
 <!--^^^^^^ meta.let.identifier.ngx -->
 <!--      ^ meta.let.ngx -->
 <!--       ^^^^^^^^^^^^^^^ meta.let.value.ngx -->
@@ -71,6 +77,7 @@
 
 <!-- qualified property with missing leading object in incomplete ternary expression -->
 @let path = .foo?.bar? ;
+<!--^^^^^^^^^^^^^^^^^^^ meta.embedded.statement.ngx.html source.ngx.embedded.html -->
 <!--^^^^^^ meta.let.identifier.ngx -->
 <!--      ^ meta.let.ngx -->
 <!--       ^ meta.let.value.ngx - meta.path -->
@@ -87,6 +94,7 @@
 <!--                   ^ punctuation.terminator.expression.ngx -->
 
 @let path = .orders.value()?.[0]?.$extra?.#currency.unit;
+<!--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.statement.ngx.html source.ngx.embedded.html -->
 <!--^^^^^^ meta.let.identifier.ngx -->
 <!--      ^ meta.let.ngx -->
 <!--       ^ meta.let.value.ngx - meta.path -->
@@ -116,6 +124,7 @@
 <!--                                                    ^ punctuation.terminator.expression.ngx -->
 
 @let path = orders.value()?.[0]?.$extra?.#currency.unit;
+<!--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.statement.ngx.html source.ngx.embedded.html -->
 <!--^^^^^^ meta.let.identifier.ngx -->
 <!--      ^ meta.let.ngx -->
 <!--       ^ meta.let.value.ngx - meta.path -->
@@ -149,9 +158,10 @@
  -->
 
 @if (a > b) {
-<!-- <- keyword.control.conditional.if.ngx punctuation.definition.keyword.ngx -->
- <!-- <- keyword.control.conditional.if.ngx -->
-  <!-- <- keyword.control.conditional.if.ngx -->
+<!--^^^^^^^^ meta.embedded.statement.ngx.html source.ngx.embedded.html -->
+<!-- <- meta.embedded.statement.ngx.html source.ngx.embedded.html keyword.control.conditional.if.ngx punctuation.definition.keyword.ngx -->
+ <!-- <- meta.embedded.statement.ngx.html source.ngx.embedded.html keyword.control.conditional.if.ngx -->
+  <!-- <- meta.embedded.statement.ngx.html source.ngx.embedded.html keyword.control.conditional.if.ngx -->
 <!--^^^^^^^ meta.group.ngx -->
 <!--^ punctuation.section.group.begin.ngx -->
 <!-- ^ variable.other.readwrite.ngx -->
@@ -173,6 +183,7 @@
 <!--                             ^^ punctuation.section.embedded.end.ngx.html - source.ngx -->
 } @else if (b > a()) {
 <!-- <- meta.block.ngx punctuation.section.block.end.ngx -->
+<!--^^^^^^^^^^^^^^^^^ meta.embedded.statement.ngx.html source.ngx.embedded.html -->
 <!--^^^^^^ keyword.control.conditional.elseif.ngx -->
 <!--       ^^^^^^^^^ meta.group.ngx -->
 <!--       ^ punctuation.section.group.begin.ngx -->
@@ -202,7 +213,8 @@
 <!--                                ^^ punctuation.section.embedded.end.ngx.html -->
 } @else {
 <!-- <- meta.block.ngx punctuation.section.block.end.ngx -->
-  <!-- <- keyword.control.conditional.else.ngx punctuation.definition.keyword.ngx -->
+  <!-- <- meta.embedded.statement.ngx.html source.ngx.embedded.html keyword.control.conditional.else.ngx punctuation.definition.keyword.ngx -->
+<!--^^^^ meta.embedded.statement.ngx.html source.ngx.embedded.html -->
 <!--^^^ keyword.control.conditional.else.ngx -->
 <!--    ^ meta.block.ngx punctuation.section.block.begin.ngx -->
     {{ a }} is equal to {{ b }}
@@ -250,6 +262,8 @@
  -->
 
 @switch (accessLevel) {
+<!-- <- meta.embedded.statement.ngx.html source.ngx.embedded.html keyword.control.conditional.switch.ngx punctuation.definition.keyword.ngx -->
+<!--^^^^^^^^^^^^^^^^^^ meta.embedded.statement.ngx.html source.ngx.embedded.html -->
 <!--^^^ keyword.control.conditional.switch.ngx -->
 <!--    ^^^^^^^^^^^^^ meta.group.ngx -->
 <!--    ^ punctuation.section.group.begin.ngx -->
@@ -257,7 +271,7 @@
 <!--                ^ punctuation.section.group.end.ngx -->
 <!--                  ^ meta.block.ngx punctuation.section.block.begin.ngx -->
     @case ('admin') {
-<!--^^^^^^^^^^^^^^^^ meta.block.ngx - meta.block meta.block -->
+<!--^^^^^^^^^^^^^^^^ meta.block.ngx meta.embedded.statement.ngx.html source.ngx.embedded.html  - meta.block meta.block -->
 <!--                ^^ meta.block.ngx meta.block.ngx -->
 <!--^^^^^ keyword.control.conditional.case.ngx -->
 <!--^ punctuation.definition.keyword.ngx -->
@@ -277,7 +291,7 @@
 <!-- ^ meta.block.ngx - meta.block meta.block -->
 
     @case {
-<!--^^^^^^ meta.block.ngx - meta.block meta.block -->
+<!--^^^^^^ meta.block.ngx meta.embedded.statement.ngx.html source.ngx.embedded.html - meta.block meta.block -->
 <!--      ^^ meta.block.ngx meta.block.ngx -->
 <!--^^^^^ keyword.control.conditional.case.ngx -->
 <!--^ punctuation.definition.keyword.ngx -->
@@ -292,7 +306,7 @@
 <!--^ meta.block.ngx meta.block.ngx punctuation.section.block.end.ngx -->
 <!-- ^ meta.block.ngx - meta.block meta.block -->
     @default {
-<!--^^^^^^^^^ meta.block.ngx - meta.block meta.block -->
+<!--^^^^^^^^^ meta.block.ngx meta.embedded.statement.ngx.html source.ngx.embedded.html - meta.block meta.block -->
 <!--         ^^ meta.block.ngx meta.block.ngx -->
 <!--^^^^^^^^ keyword.control.conditional.case.ngx -->
 <!--^ punctuation.definition.keyword.ngx -->
@@ -311,6 +325,8 @@
  -->
 
 @for (user of users; track user.id) {
+<!-- <- meta.embedded.statement.ngx source.ngx.embedded.html keyword.control.loop.for.ngx punctuation.definition.keyword.ngx -->
+<!--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.statement.ngx source.ngx.embedded.html -->
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.ngx -->
 <!-- ^ punctuation.section.group.begin.ngx -->
 <!--  ^^^^ variable.other.readwrite.ngx -->
@@ -326,14 +342,16 @@
   {{ user.name }}
 } @empty {
 <!-- <- meta.block.ngx punctuation.section.block.end.ngx -->
-  <!-- <- keyword.control.loop.else.ngx punctuation.definition.keyword.ngx -->
-<!--^^^^ keyword.control.loop.else.ngx -->
+  <!-- <- meta.embedded.statement.ngx source.ngx.embedded.html keyword.control.loop.else.ngx punctuation.definition.keyword.ngx -->
+<!--^^^^ meta.embedded.statement.ngx source.ngx.embedded.html keyword.control.loop.else.ngx -->
+<!--    ^ meta.embedded.statement.ngx source.ngx.embedded.html - keyword - punctuation -->
 <!--     ^ meta.block.ngx punctuation.section.block.begin.ngx -->
   Empty list of users
-}
-<!-- <- meta.block.ngx punctuation.section.block.end.ngx -->
+.html}
+<!--.html <- meta.block.ngx punctuation.section.block.end.ngx -->
 
 @for (item of items; track item.id; let idx = $index, e = $even) {
+<!--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.statement.ngx source.ngx.embedded.html -->
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.ngx -->
 <!-- ^ punctuation.section.group.begin.ngx -->
 <!--  ^^^^ variable.other.readwrite.ngx -->
@@ -370,9 +388,11 @@
 <!--                       ^^^^ variable.other.member.ngx -->
 <!--                            ^^ punctuation.section.embedded.end.ngx.html -->
 }
-<!-- <- meta.block.ngx punctuation.section.block.end.ngx -->
+<!--.html <- meta.block.ngx punctuation.section.block.end.ngx -->
 
 @if (users$ | async; as users) {
+<!-- <- meta.embedded.statement.ngx source.ngx.embedded.html keyword.control.conditional.if.ngx punctuation.definition.keyword.ngx -->
+<!--^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.statement.ngx source.ngx.embedded.html -->
 <!--^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.ngx -->
 <!--^ punctuation.section.group.begin.ngx -->
 <!-- ^^^^^^ variable.other.readwrite.ngx -->
@@ -402,7 +422,7 @@
 <!--                       ^ entity.name.tag.block.any.html -->
 <!--                        ^ punctuation.definition.tag.end.html -->
 }
-<!-- <- meta.block.ngx punctuation.section.block.end.ngx -->
+<!--.html <- meta.block.ngx punctuation.section.block.end.ngx -->
 
 
 <!--
@@ -411,6 +431,7 @@
  -->
 
     @defer { <comment-list /> }
+<!--^^^^^^^ meta.embedded.statement.ngx.html source.ngx.embedded.html -->
 <!--^^^^^^ keyword.control.flow.ngx -->
 <!--^ punctuation.definition.keyword.ngx -->
 <!--       ^^^^^^^^^^^^^^^^^^^^ meta.block.ngx -->
@@ -422,6 +443,7 @@
 <!--                          ^ punctuation.section.block.end.ngx -->
 
     @defer (on viewport) {
+<!--^^^^^^^^^^^^^^^^^^^^^ meta.embedded.statement.ngx.html source.ngx.embedded.html -->
 <!--^^^^^^ keyword.control.flow.ngx -->
 <!--^ punctuation.definition.keyword.ngx -->
 <!--       ^^^^^^^^^^^^^ meta.group.ngx -->
@@ -433,18 +455,21 @@
         <comment-list />
     } @loading {
 <!--^ meta.block.ngx punctuation.section.block.end.ngx -->
+<!--  ^^^^^^^^^ meta.embedded.statement.ngx.html source.ngx.embedded.html -->
 <!--  ^^^^^^^^ keyword.control.flow.ngx -->
 <!--  ^ punctuation.definition.keyword.ngx -->
 <!--           ^ meta.block.ngx punctuation.section.block.begin.ngx -->
       Loading…
     } @error {
 <!--^ meta.block.ngx punctuation.section.block.end.ngx -->
+<!--  ^^^^^^^ meta.embedded.statement.ngx.html source.ngx.embedded.html -->
 <!--  ^^^^^^ keyword.control.flow.ngx -->
 <!--  ^ punctuation.definition.keyword.ngx -->
 <!--         ^ meta.block.ngx punctuation.section.block.begin.ngx -->
       Loading failed :(
     } @placeholder {
 <!--^ meta.block.ngx punctuation.section.block.end.ngx -->
+<!--  ^^^^^^^^^^^^^ meta.embedded.statement.ngx.html source.ngx.embedded.html -->
 <!--  ^^^^^^^^^^^^ keyword.control.flow.ngx -->
 <!--  ^ punctuation.definition.keyword.ngx -->
 <!--               ^ meta.block.ngx punctuation.section.block.begin.ngx -->
@@ -454,6 +479,7 @@
 <!-- ^ - meta.block -->
 
 @defer (on viewport; when $var prefetch on idle; prefetch when true) {
+<!--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.statement.ngx.html source.ngx.embedded.html -->
 <!--   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.ngx -->
 <!--   ^ punctuation.section.group.begin.ngx -->
 <!--    ^^ keyword.control.flow.ngx -->

--- a/tests/syntax_test_scopes.component.html
+++ b/tests/syntax_test_scopes.component.html
@@ -743,6 +743,79 @@
 
 
 <!--
+ String interpolations
+ -->
+
+ <![CDATA[string {{value}}!]]>
+<!--^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.sgml.cdata.html -->
+<!--^^^^^ keyword.declaration.cdata.html -->
+<!--     ^ punctuation.definition.tag.begin.html -->
+<!--      ^^^^^^^^^^^^^^^^^ meta.string.html -->
+<!--      ^^^^^^^ string.unquoted.cdata.html -->
+<!--             ^^^^^^^^^ meta.embedded.expression.ngx.html -->
+<!--             ^^ punctuation.section.embedded.begin.ngx.html -->
+<!--               ^^^^^ source.ngx.embedded.html variable.other.readwrite.ngx -->
+<!--                    ^^ punctuation.section.embedded.end.ngx.html -->
+<!--                      ^ string.unquoted.cdata.html -->
+<!--                       ^^^ punctuation.definition.tag.end.html -->
+
+<!-- generic attributes -->
+<div width="{{width}}px">
+<!--^^^^^^^^^^^^^^^^^^^^^ meta.tag -->
+<!-- ^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.html -->
+<!-- ^^^^^ entity.other.attribute-name.html -->
+<!--      ^ punctuation.separator.key-value.html -->
+<!--       ^ meta.string.html string.quoted.double.html punctuation.definition.string.begin.html -->
+<!--        ^^^^^^^^^ meta.string.html meta.embedded.expression.ngx.html -->
+<!--        ^^ punctuation.section.embedded.begin.ngx.html -->
+<!--          ^^^^^ source.ngx.embedded.html variable.other.readwrite.ngx -->
+<!--               ^^ punctuation.section.embedded.end.ngx.html -->
+<!--                 ^^^ meta.string.html string.quoted.double.html -->
+<!--                   ^ punctuation.definition.string.end.html -->
+<!--                    ^ punctuation.definition.tag.end.html -->
+
+<!-- class attributes -->
+<div class="{{class}}-name">
+<!--^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.block.any.html -->
+<!-- ^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.class.html -->
+<!-- ^^^^^ entity.other.attribute-name.class.html -->
+<!--      ^ punctuation.separator.key-value.html -->
+<!--       ^ meta.string.html string.quoted.double.html punctuation.definition.string.begin.html -->
+<!--        ^^^^^^^^^^^^^^ meta.class-name.html meta.string.html -->
+<!--        ^^^^^^^^^ meta.embedded.expression.ngx.html -->
+<!--        ^^ punctuation.section.embedded.begin.ngx.html -->
+<!--          ^^^^^ source.ngx.embedded.html variable.other.readwrite.ngx -->
+<!--               ^^ punctuation.section.embedded.end.ngx.html -->
+<!--                 ^^^^^ string.quoted.double.html -->
+<!--                      ^ meta.string.html string.quoted.double.html punctuation.definition.string.end.html -->
+<!--                       ^ punctuation.definition.tag.end.html -->
+
+<!-- CSS attributes -->
+<div style="{{prop}}-name: {{value + " >
+<!--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.block.any.html -->
+<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.style.html -->
+<!--                                  ^^ - meta.attribute-with-value -->
+<!-- ^^^^^ entity.other.attribute-name.style.html -->
+<!--      ^ punctuation.separator.key-value.html -->
+<!--       ^ meta.string.html string.quoted.double.html punctuation.definition.string.begin.html -->
+<!--        ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.html source.css.embedded.html -->
+<!--        ^^^^^^^^ meta.embedded.expression.ngx.html -->
+<!--        ^^ punctuation.section.embedded.begin.ngx.html -->
+<!--          ^^^^ source.ngx.embedded.html variable.other.readwrite.ngx -->
+<!--              ^^ punctuation.section.embedded.end.ngx.html -->
+<!--                ^^^^^ meta.property-name.css support.type.property-name.css -->
+<!--                     ^ punctuation.separator.key-value.css -->
+<!--                      ^^^^^^^^^^^ meta.property-value.css -->
+<!--                       ^^^^^^^^^^ meta.embedded.expression.ngx.html -->
+<!--                       ^^ punctuation.section.embedded.begin.ngx.html -->
+<!--                         ^^^^^^^^ source.ngx.embedded.html -->
+<!--                         ^^^^^ variable.other.readwrite.ngx -->
+<!--                               ^ keyword.operator.arithmetic.ngx -->
+<!--                                 ^ meta.string.html string.quoted.double.html punctuation.definition.string.end.html -->
+<!--                                   ^ punctuation.definition.tag.end.html -->
+
+
+<!--
  Binding dynamic text, properties and attributes
  https://v18.angular.dev/guide/templates/binding#binding-dynamic-properties-and-attributes
  -->

--- a/tests/syntax_test_scopes.component.html
+++ b/tests/syntax_test_scopes.component.html
@@ -743,6 +743,29 @@
 
 
 <!--
+ Interpolation in inline styles
+ -->
+
+<style>
+    #{{id}} {
+        {{prop}}: {{value}};
+<!--^^^^^^^^^^^^^^^^^^^^^^^^ source.css.embedded.html meta.property-list.css meta.block.css -->
+<!--    ^^^^^^^^ meta.property-name.css support.type.property-name.css meta.embedded.expression.ngx.html -->
+<!--    ^^ punctuation.section.embedded.begin.ngx.html -->
+<!--      ^^^^ source.ngx.embedded.html variable.other.readwrite.ngx -->
+<!--          ^^ punctuation.section.embedded.end.ngx.html -->
+<!--            ^ punctuation.separator.key-value.css -->
+<!--             ^^^^^^^^^^ meta.property-value.css -->
+<!--              ^^^^^^^^^ meta.embedded.expression.ngx.html -->
+<!--              ^^ punctuation.section.embedded.begin.ngx.html -->
+<!--                ^^^^^ source.ngx.embedded.html variable.other.readwrite.ngx -->
+<!--                     ^^ punctuation.section.embedded.end.ngx.html -->
+<!--                       ^ punctuation.terminator.rule.css -->
+    }
+</style>
+
+
+<!--
  String interpolations
  -->
 

--- a/tests/syntax_test_scopes.component.html
+++ b/tests/syntax_test_scopes.component.html
@@ -160,9 +160,9 @@
 <!--      ^ punctuation.section.group.end.ngx -->
 <!--        ^ meta.block.ngx punctuation.section.block.begin.ngx -->
     {{ a }} is greater than {{ b }}
-<!--^^^^^^^ meta.block.ngx meta.embedded.ngx.html -->
-<!--       ^^^^^^^^^^^^^^^^^ meta.block.ngx - meta.embedded -->
-<!--                        ^^^^^^^ meta.block.ngx meta.embedded.ngx.html -->
+<!--^^^^^^^ meta.block.ngx meta.embedded.expression.ngx.html -->
+<!--       ^^^^^^^^^^^^^^^^^ meta.block.ngx - meta.embedded.expression -->
+<!--                        ^^^^^^^ meta.block.ngx meta.embedded.expression.ngx.html -->
 <!--^^ punctuation.section.embedded.begin.ngx.html -->
 <!--  ^^^ source.ngx.embedded.html -->
 <!--   ^ variable.other.readwrite.ngx -->
@@ -184,9 +184,9 @@
 <!--               ^ punctuation.section.group.end.ngx -->
 <!--                 ^ meta.block.ngx punctuation.section.block.begin.ngx -->
     {{ a() }} is less than {{ b.c() }}
-<!--^^^^^^^^^ meta.block.ngx meta.embedded.ngx.html -->
-<!--         ^^^^^^^^^^^^^^ meta.block.ngx - meta.embedded -->
-<!--                       ^^^^^^^^^^^ meta.block.ngx meta.embedded.ngx.html -->
+<!--^^^^^^^^^ meta.block.ngx meta.embedded.expression.ngx.html -->
+<!--         ^^^^^^^^^^^^^^ meta.block.ngx - meta.embedded.expression -->
+<!--                       ^^^^^^^^^^^ meta.block.ngx meta.embedded.expression.ngx.html -->
 <!--^^ punctuation.section.embedded.begin.ngx.html -->
 <!--  ^^^^^ source.ngx.embedded.html -->
 <!--   ^ meta.function-call.identifier.ngx variable.function.ngx -->
@@ -206,9 +206,9 @@
 <!--^^^ keyword.control.conditional.else.ngx -->
 <!--    ^ meta.block.ngx punctuation.section.block.begin.ngx -->
     {{ a }} is equal to {{ b }}
-<!--^^^^^^^ meta.block.ngx meta.embedded.ngx.html -->
-<!--       ^^^^^^^^^^^^^ meta.block.ngx - meta.embedded -->
-<!--                    ^^^^^^^ meta.block.ngx meta.embedded.ngx.html -->
+<!--^^^^^^^ meta.block.ngx meta.embedded.expression.ngx.html -->
+<!--       ^^^^^^^^^^^^^ meta.block.ngx - meta.embedded.expression -->
+<!--                    ^^^^^^^ meta.block.ngx meta.embedded.expression.ngx.html -->
 <!--  ^^^ source.ngx.embedded.html -->
 <!--   ^ variable.other.readwrite.ngx -->
 <!--     ^^ punctuation.section.embedded.end.ngx.html -->
@@ -235,7 +235,7 @@
 <!--                                              ^ punctuation.section.group.end.ngx -->
 <!--                                                ^ meta.block.ngx punctuation.section.block.begin.ngx -->
     {{ startDate }}
-<!--^^^^^^^^^^^^^^^ text.html.ngx meta.block.ngx meta.embedded.ngx.html -->
+<!--^^^^^^^^^^^^^^^ text.html.ngx meta.block.ngx meta.embedded.expression.ngx.html -->
 <!--^^ punctuation.section.embedded.begin.ngx.html -->
 <!--  ^^^^^^^^^^^ source.ngx.embedded.html -->
 <!--   ^^^^^^^^^ variable.other.readwrite.ngx -->
@@ -357,12 +357,12 @@
 <!--                                                             ^ meta.block.ngx punctuation.section.block.begin.ngx -->
   Item #{{ idx }}: {{ item.name }}
 <!--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.ngx -->
-<!--    ^^^^^^^^^ meta.embedded.ngx.html -->
+<!--    ^^^^^^^^^ meta.embedded.expression.ngx.html -->
 <!--    ^^ punctuation.section.embedded.begin.ngx.html -->
 <!--      ^^^^^ source.ngx.embedded.html -->
 <!--       ^^^ variable.other.readwrite.ngx -->
 <!--           ^^ punctuation.section.embedded.end.ngx.html -->
-<!--               ^^^^^^^^^^^^^^^ meta.embedded.ngx.html -->
+<!--               ^^^^^^^^^^^^^^^ meta.embedded.expression.ngx.html -->
 <!--               ^^ punctuation.section.embedded.begin.ngx.html -->
 <!--                 ^^^^^^^^^^^ source.ngx.embedded.html -->
 <!--                  ^^^^ variable.other.object.ngx -->
@@ -390,7 +390,7 @@
 <!--^ punctuation.definition.tag.begin.html -->
 <!-- ^ entity.name.tag.block.any.html -->
 <!--  ^ punctuation.definition.tag.end.html -->
-<!--   ^^^^^^^^^^^^^^^^^^ meta.embedded.ngx.html -->
+<!--   ^^^^^^^^^^^^^^^^^^ meta.embedded.expression.ngx.html -->
 <!--   ^^ punctuation.section.embedded.begin.ngx.html -->
 <!--     ^^^^^^^^^^^^^^ source.ngx.embedded.html -->
 <!--      ^^^^^ variable.other.object.ngx -->
@@ -489,7 +489,7 @@
 
   <!-- escaped chars -->
   {{ "\xAF \u2AFF \n \"" }}
-<!--^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.ngx.html -->
+<!--^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.expression.ngx.html -->
 <!--^^^^^^^^^^^^^^^^^^^^^ source.ngx.embedded.html -->
 <!-- ^^^^^^^^^^^^^^^^^^^ meta.string.ngx string.quoted.double.ngx -->
 <!-- ^ punctuation.definition.string.begin.ngx -->
@@ -534,7 +534,7 @@
 
   <!-- objects -->
   {{ { name: 'Alice', 'object': { array + "name": [0, 2, 3] } } }}
-<!--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.ngx.html -->
+<!--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.expression.ngx.html -->
 <!--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.ngx.embedded.html -->
 <!-- ^^ meta.mapping.ngx - meta.mapping meta.mapping -->
 <!--   ^^^^ meta.mapping.key.ngx - meta.mapping meta.mapping -->
@@ -607,7 +607,7 @@
 
   <!-- ternary -->
   {{ foo ? bar : baz }}
-<!--^^^^^^^^^^^^^^^^^^^ meta.embedded.ngx.html -->
+<!--^^^^^^^^^^^^^^^^^^^ meta.embedded.expression.ngx.html -->
 <!--^^^^^^^^^^^^^^^^^ source.ngx.embedded.html -->
 <!-- ^^^ variable.other.readwrite.ngx -->
 <!--     ^ keyword.operator.ternary.ngx -->
@@ -618,7 +618,7 @@
 
   <!-- null coalescing -->
   {{ foo = null ?? 'default' }}
-<!--^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.ngx.html -->
+<!--^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.expression.ngx.html -->
 <!--^^^^^^^^^^^^^^^^^^^^^^^^^ source.ngx.embedded.html -->
 <!-- ^^^ variable.other.readwrite.ngx -->
 <!--     ^ keyword.operator.assignment.ngx -->
@@ -631,7 +631,7 @@
 
   <!-- property subscription -->
   {{ person['name'][0] = "Mirabel" }}
-<!--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.ngx.html -->
+<!--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.expression.ngx.html -->
 <!--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.ngx.embedded.html - meta.path -->
 <!-- ^^^^^^ variable.other.readwrite.ngx -->
 <!--       ^^^^^^^^^^^ meta.subscription.ngx -->
@@ -650,20 +650,20 @@
 <!--                               ^^ punctuation.section.embedded.end.ngx.html -->
 
   {{ obj?.member }}
-<!--^ meta.embedded.ngx.html source.ngx.embedded.html - meta.path -->
-<!-- ^^^^^^^^^^^ meta.embedded.ngx.html source.ngx.embedded.html meta.path.ngx - meta.path meta.path -->
-<!--            ^ meta.embedded.ngx.html source.ngx.embedded.html - meta.path -->
-<!--             ^^ meta.embedded.ngx.html - source.ngx -->
+<!--^ meta.embedded.expression.ngx.html source.ngx.embedded.html - meta.path -->
+<!-- ^^^^^^^^^^^ meta.embedded.expression.ngx.html source.ngx.embedded.html meta.path.ngx - meta.path meta.path -->
+<!--            ^ meta.embedded.expression.ngx.html source.ngx.embedded.html - meta.path -->
+<!--             ^^ meta.embedded.expression.ngx.html - source.ngx -->
 <!-- ^^^ variable.other.object.ngx -->
 <!--    ^^ punctuation.accessor.ngx -->
 <!--      ^^^^^^ variable.other.member.ngx -->
 <!--             ^^ punctuation.section.embedded.end.ngx.html -->
 
   {{ obj.member [5] }}
-<!--^ meta.embedded.ngx.html source.ngx.embedded.html - meta.path -->
-<!-- ^^^^^^^^^^^^^^ meta.embedded.ngx.html source.ngx.embedded.html meta.path.ngx - meta.path meta.path -->
-<!--               ^ meta.embedded.ngx.html source.ngx.embedded.html - meta.path -->
-<!--                ^^ meta.embedded.ngx.html - source.ngx -->
+<!--^ meta.embedded.expression.ngx.html source.ngx.embedded.html - meta.path -->
+<!-- ^^^^^^^^^^^^^^ meta.embedded.expression.ngx.html source.ngx.embedded.html meta.path.ngx - meta.path meta.path -->
+<!--               ^ meta.embedded.expression.ngx.html source.ngx.embedded.html - meta.path -->
+<!--                ^^ meta.embedded.expression.ngx.html - source.ngx -->
 <!-- ^^^ variable.other.object.ngx -->
 <!--    ^ punctuation.accessor.ngx -->
 <!--     ^^^^^^ variable.other.member.ngx -->
@@ -672,10 +672,10 @@
 <!--                ^^ punctuation.section.embedded.end.ngx.html -->
 
   {{ obj.method() }}
-<!--^ meta.embedded.ngx.html source.ngx.embedded.html - meta.path -->
-<!-- ^^^^^^^^^^^^ meta.embedded.ngx.html source.ngx.embedded.html meta.path.ngx - meta.path meta.path -->
-<!--             ^ meta.embedded.ngx.html source.ngx.embedded.html - meta.path -->
-<!--              ^^ meta.embedded.ngx.html - source.ngx -->
+<!--^ meta.embedded.expression.ngx.html source.ngx.embedded.html - meta.path -->
+<!-- ^^^^^^^^^^^^ meta.embedded.expression.ngx.html source.ngx.embedded.html meta.path.ngx - meta.path meta.path -->
+<!--             ^ meta.embedded.expression.ngx.html source.ngx.embedded.html - meta.path -->
+<!--              ^^ meta.embedded.expression.ngx.html - source.ngx -->
 <!-- ^^^ variable.other.object.ngx -->
 <!--    ^ punctuation.accessor.ngx -->
 <!--     ^^^^^^ meta.function-call.identifier.ngx variable.function.method.ngx -->
@@ -685,10 +685,10 @@
 <!--              ^^ punctuation.section.embedded.end.ngx.html -->
 
   {{ orders.value()?.[0]?.$extra?.#currency }}
-<!--^ meta.embedded.ngx.html source.ngx.embedded.html - meta.path -->
-<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.ngx.html source.ngx.embedded.html meta.path.ngx - meta.path meta.path -->
-<!--                                       ^ meta.embedded.ngx.html source.ngx.embedded.html - meta.path -->
-<!--                                        ^^ meta.embedded.ngx.html - source.ngx -->
+<!--^ meta.embedded.expression.ngx.html source.ngx.embedded.html - meta.path -->
+<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.expression.ngx.html source.ngx.embedded.html meta.path.ngx - meta.path meta.path -->
+<!--                                       ^ meta.embedded.expression.ngx.html source.ngx.embedded.html - meta.path -->
+<!--                                        ^^ meta.embedded.expression.ngx.html - source.ngx -->
 <!-- ^^^^^^ variable.other.object.ngx -->
 <!--       ^ punctuation.accessor.ngx -->
 <!--        ^^^^^ meta.function-call.identifier.ngx variable.function.method.ngx -->
@@ -709,7 +709,7 @@
 <!--                                        ^^ punctuation.section.embedded.end.ngx.html -->
 
   {{ func(arg, "value") }}
-<!--^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.ngx.html -->
+<!--^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.expression.ngx.html -->
 <!--^^^^^^^^^^^^^^^^^^^^ source.ngx.embedded.html -->
 <!-- ^^^^ meta.function-call.identifier.ngx variable.function.ngx -->
 <!--     ^^^^^^^^^^^^^^ meta.function-call.arguments.ngx -->
@@ -723,7 +723,7 @@
 <!--                    ^^ punctuation.section.embedded.end.ngx.html -->
 
   {{ var | filter | annimation ("forward") }}
-<!--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.ngx.html -->
+<!--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.expression.ngx.html -->
 <!--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.ngx.embedded.html -->
 <!-- ^^^ variable.other.readwrite.ngx -->
 <!--     ^^^^^^^^ meta.filter.ngx -->
@@ -757,7 +757,7 @@
 <!--       ^ punctuation.definition.bind.end.ngx -->
 <!--        ^ punctuation.separator.key-value.ngx -->
 <!--         ^ string.quoted.double.ngx punctuation.definition.string.begin.ngx -->
-<!--          ^^^^^^^^^^^^^^^ meta.interpolation.ngx source.ngx.embedded.html - string -->
+<!--          ^^^^^^^^^^^^^^^ meta.embedded.expression.ngx source.ngx.embedded.html - string -->
 <!--          ^^^ variable.other.readwrite.ngx -->
 <!--              ^ keyword.operator.arithmetic.ngx -->
 <!--                ^^^ variable.other.readwrite.ngx -->
@@ -776,7 +776,7 @@
 <!--            ^ punctuation.definition.bind.end.ngx -->
 <!--             ^ punctuation.separator.key-value.ngx -->
 <!--              ^ string.quoted.double.ngx punctuation.definition.string.begin.ngx -->
-<!--               ^^^^^^^^^^^^^^^ meta.interpolation.ngx source.ngx.embedded.html - string -->
+<!--               ^^^^^^^^^^^^^^^ meta.embedded.expression.ngx source.ngx.embedded.html - string -->
 <!--               ^^^ variable.other.readwrite.ngx -->
 <!--                   ^ keyword.operator.arithmetic.ngx -->
 <!--                     ^^^ variable.other.readwrite.ngx -->
@@ -801,7 +801,7 @@
 <!--        ^ punctuation.definition.on.end.ngx -->
 <!--         ^ punctuation.separator.key-value.ngx -->
 <!--          ^ string.quoted.double.ngx punctuation.definition.string.begin.ngx -->
-<!--           ^^^^^^^^^^^^^^^ meta.interpolation.ngx source.ngx.embedded.html - string -->
+<!--           ^^^^^^^^^^^^^^^ meta.embedded.expression.ngx source.ngx.embedded.html - string -->
 <!--           ^^^ variable.other.readwrite.ngx -->
 <!--               ^ keyword.operator.arithmetic.ngx -->
 <!--                 ^^^ variable.other.readwrite.ngx -->
@@ -820,7 +820,7 @@
 <!--                  ^ punctuation.definition.on.end.ngx -->
 <!--                   ^ punctuation.separator.key-value.ngx -->
 <!--                    ^ string.quoted.double.ngx punctuation.definition.string.begin.ngx -->
-<!--                     ^^^^^^^^^^^^^^^ meta.interpolation.ngx source.ngx.embedded.html - string -->
+<!--                     ^^^^^^^^^^^^^^^ meta.embedded.expression.ngx source.ngx.embedded.html - string -->
 <!--                     ^^^ variable.other.readwrite.ngx -->
 <!--                         ^ keyword.operator.arithmetic.ngx -->
 <!--                           ^^^ variable.other.readwrite.ngx -->
@@ -845,7 +845,7 @@
 <!--            ^^ punctuation.definition.bindon.end.ngx -->
 <!--              ^ punctuation.separator.key-value.ngx -->
 <!--               ^ string.quoted.double.ngx punctuation.definition.string.begin.ngx -->
-<!--                ^^^^^^^^^^^^^^^ meta.interpolation.ngx source.ngx.embedded.html - string -->
+<!--                ^^^^^^^^^^^^^^^ meta.embedded.expression.ngx source.ngx.embedded.html - string -->
 <!--                ^^^ variable.other.readwrite.ngx -->
 <!--                    ^ keyword.operator.arithmetic.ngx -->
 <!--                      ^^^ variable.other.readwrite.ngx -->
@@ -868,7 +868,7 @@
 <!--  ^^^^^^^^^ entity.other.attribute-name.reference.ngx -->
 <!--           ^ punctuation.separator.key-value.ngx -->
 <!--            ^ string.quoted.double.ngx punctuation.definition.string.begin.ngx -->
-<!--             ^^^^^^^^^^^^^^^ meta.interpolation.ngx source.ngx.embedded.html - string -->
+<!--             ^^^^^^^^^^^^^^^ meta.embedded.expression.ngx source.ngx.embedded.html - string -->
 <!--             ^^^ variable.other.readwrite.ngx -->
 <!--                 ^ keyword.operator.arithmetic.ngx -->
 <!--                   ^^^ variable.other.readwrite.ngx -->
@@ -892,7 +892,7 @@
 <!--  ^^^^^^^^ entity.other.attribute-name.template.ngx -->
 <!--          ^ punctuation.separator.key-value.ngx -->
 <!--           ^ string.quoted.double.ngx punctuation.definition.string.begin.ngx -->
-<!--            ^^^^^^^^^^^^^^^ meta.interpolation.ngx source.ngx.embedded.html - string -->
+<!--            ^^^^^^^^^^^^^^^ meta.embedded.expression.ngx source.ngx.embedded.html - string -->
 <!--            ^^^ variable.other.readwrite.ngx -->
 <!--                ^ keyword.operator.arithmetic.ngx -->
 <!--                  ^^^ variable.other.readwrite.ngx -->
@@ -916,7 +916,7 @@
 <!--  ^^^^ keyword.control.conditional.if.ngx -->
 <!--      ^ punctuation.separator.key-value.ngx -->
 <!--       ^ string.quoted.double.ngx punctuation.definition.string.begin.ngx -->
-<!--        ^^^^^^^^^^^ meta.interpolation.ngx source.ngx.embedded.html -->
+<!--        ^^^^^^^^^^^ meta.embedded.expression.ngx source.ngx.embedded.html -->
 <!--        ^^^^ variable.other.readwrite.ngx -->
 <!--             ^ keyword.operator.assignment.ngx -->
 <!--               ^^^^ constant.language.boolean.true.ngx -->
@@ -932,7 +932,7 @@
 <!--  ^^^^^ keyword.control.loop.for.ngx -->
 <!--       ^ punctuation.separator.key-value.ngx -->
 <!--        ^ string.quoted.double.ngx punctuation.definition.string.begin.ngx -->
-<!--         ^^^^^^^^^^^^^^^^^^^^^ meta.interpolation.ngx source.ngx.embedded.html -->
+<!--         ^^^^^^^^^^^^^^^^^^^^^ meta.embedded.expression.ngx source.ngx.embedded.html -->
 <!--         ^^^ keyword.declation.variable.ngx -->
 <!--             ^^^^^^ variable.other.readwrite.ngx -->
 <!--                    ^^ keyword.operator.iteration.ngx -->
@@ -949,7 +949,7 @@
 <!--  ^^^^^ keyword.control.loop.for.ngx -->
 <!--       ^ punctuation.separator.key-value.ngx -->
 <!--        ^ string.quoted.double.ngx punctuation.definition.string.begin.ngx -->
-<!--         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.interpolation.ngx source.ngx.embedded.html -->
+<!--         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.expression.ngx source.ngx.embedded.html -->
 <!--         ^^^ keyword.declation.variable.ngx -->
 <!--             ^^^^ variable.other.readwrite.ngx -->
 <!--                  ^^ keyword.operator.iteration.ngx -->
@@ -971,7 +971,7 @@
 <!--          ^ punctuation.definition.bind.end.ngx -->
 <!--           ^ punctuation.separator.key-value.ngx -->
 <!--            ^ string.quoted.double.ngx punctuation.definition.string.begin.ngx -->
-<!--             ^^^^^^^^^^^^^^^^^^^ meta.interpolation.ngx source.ngx.embedded.html meta.path.ngx -->
+<!--             ^^^^^^^^^^^^^^^^^^^ meta.embedded.expression.ngx source.ngx.embedded.html meta.path.ngx -->
 <!--             ^^^^^^^^^^^ variable.other.object.ngx -->
 <!--                        ^ punctuation.accessor.ngx -->
 <!--                         ^^^^^^^ variable.other.member.ngx -->
@@ -987,7 +987,7 @@
 <!--             ^^^^^^^^^^^^ keyword.control.conditional.case.ngx -->
 <!--                         ^ punctuation.separator.key-value.ngx -->
 <!--                          ^ string.quoted.double.ngx punctuation.definition.string.begin.ngx -->
-<!--                           ^^^^^^^ meta.interpolation.ngx source.ngx.embedded.html meta.string.ngx string.quoted.single.ngx -->
+<!--                           ^^^^^^^ meta.embedded.expression.ngx source.ngx.embedded.html meta.string.ngx string.quoted.single.ngx -->
 <!--                           ^ punctuation.definition.string.begin.ngx -->
 <!--                                 ^ punctuation.definition.string.end.ngx -->
 <!--                                  ^ string.quoted.double.ngx punctuation.definition.string.end.ngx -->
@@ -999,7 +999,7 @@
 <!--                                          ^ punctuation.separator.key-value.ngx -->
 <!--                                           ^^^^^^^^^^^^^ meta.directive.value.ngx meta.string.ngx -->
 <!--                                           ^ string.quoted.double.ngx punctuation.definition.string.begin.ngx -->
-<!--                                            ^^^^^^^^^^^ meta.interpolation.ngx source.ngx.embedded.html variable.other.readwrite.ngx -->
+<!--                                            ^^^^^^^^^^^ meta.embedded.expression.ngx source.ngx.embedded.html variable.other.readwrite.ngx -->
 <!--                                                       ^ string.quoted.double.ngx punctuation.definition.string.end.ngx -->
 <!--                                                         ^^ punctuation.definition.tag.end.html -->
 
@@ -1016,6 +1016,6 @@
 <!--                                     ^ punctuation.separator.key-value.ngx -->
 <!--                                      ^^^^^^^^^^^^^ meta.directive.value.ngx meta.string.ngx -->
 <!--                                      ^ string.quoted.double.ngx punctuation.definition.string.begin.ngx -->
-<!--                                       ^^^^^^^^^^^ meta.interpolation.ngx source.ngx.embedded.html variable.other.readwrite.ngx -->
+<!--                                       ^^^^^^^^^^^ meta.embedded.expression.ngx source.ngx.embedded.html variable.other.readwrite.ngx -->
 <!--                                                  ^ string.quoted.double.ngx punctuation.definition.string.end.ngx -->
 <!--                                                    ^^ punctuation.definition.tag.end.html -->


### PR DESCRIPTION
This PR...

fixes #33

1. adds support for `{{ ... }}` interpolation in attribute values, quoted strings and CDATA content tags, including inline styles or code of possible `<style>` tags.
2. scopes `{{ ... }}` `meta.embedded.expression` to distinguish from control flow statements.
4. adds `meta.embedded.statement` to control flow statements such as `@if`, `@for`, etc.
5. scopes whole component content `meta.template.ngx` to align with Jinja2, Twig, Vue and others.


Note: We could also scope `{{...}}` `meta.interpolation` as those actually inject expression evaluation results into output text. However it is not easy in all template languages to make that distinction. Hence in favor of consistent scoping `meta.embedded.expression` is used. It also allows simpler snippet/completion selectors targeting both, statements and interpolation via `meta.template.ngx meta.embedded`. Jinja2, Twig, Svelte already use that schema as well.