### PR TITLE
Add Ngx v19 and v20 language features

### DIFF
--- a/Embeddings/RegExp (for Ngx Template Strings).sublime-syntax
+++ b/Embeddings/RegExp (for Ngx Template Strings).sublime-syntax
@@ -1,0 +1,14 @@
+%YAML 1.2
+---
+scope: source.regexp.embedded.ngx.template-string
+version: 2
+hidden: true
+
+extends: Packages/Regular Expressions/RegExp (Basic).sublime-syntax
+
+contexts:
+
+  prototype:
+    - match: (?=/?`)
+      pop: 1
+    - include: NgxHTML.sublime-syntax#ng-template-text-interpolations

--- a/NgxHTML.sublime-syntax
+++ b/NgxHTML.sublime-syntax
@@ -553,7 +553,7 @@ contexts:
       scope: punctuation.terminator.expression.ngx
     - match: '[!=]==?|[<>]=?'
       scope: keyword.operator.comparison.ngx
-    - match: '[-+*/%]'
+    - match: '\*\*|[-+*/%]'
       scope: keyword.operator.arithmetic.ngx
     - match: '&&|\|\||!'
       scope: keyword.operator.logical.ngx

--- a/NgxHTML.sublime-syntax
+++ b/NgxHTML.sublime-syntax
@@ -564,6 +564,8 @@ contexts:
     - match: \?(?!\.)
       scope: keyword.operator.ternary.ngx
       push: ng-ternary-expression
+    - match: (?:typeof|void){{ident_break}}
+      scope: keyword.operator.type.ngx
 
   ng-ternary-expression:
     - match: ':'

--- a/NgxHTML.sublime-syntax
+++ b/NgxHTML.sublime-syntax
@@ -426,6 +426,7 @@ contexts:
     - include: ng-constants
     - include: ng-numbers
     - include: ng-strings
+    - include: ng-templates
     - include: ng-variables
 
 ###[ ANGULAR ARRAYS ]##########################################################
@@ -668,6 +669,92 @@ contexts:
       scope: constant.character.escape.unicode.16bit.ngx
     - match: \\.
       scope: constant.character.escape.ngx
+
+  ng-templates:
+    # tagged template strings
+    - match: ({{ident_name}})(\`)
+      captures:
+        1: variable.function.tagged-template.ngx
+        2: meta.string.template.ngx string.quoted.other.ngx punctuation.definition.string.begin.ngx
+      push: ng-tagged-template-plain-body
+    # untagged plain or regexp template strings
+    - match: \`
+      scope: string.quoted.other.ngx punctuation.definition.string.begin.ngx
+      branch_point: template-string
+      branch:
+        - ng-template-pattern-begin
+        - ng-template-plain-body
+
+  ng-tagged-template-plain-body:
+    - meta_content_scope: meta.string.template.ngx string.quoted.other.ngx
+    - include: ng-tagged-template-plain-end
+    - include: ng-template-string-interpolations
+    - include: ng-string-content
+
+  ng-tagged-template-plain-end:
+    - match: \`
+      scope: meta.string.template.ngx string.quoted.other.ngx punctuation.definition.string.end.ngx
+      pop: 1
+    - match: \n
+      scope: invalid.illegal.newline.ngx
+      pop: 1
+
+  ng-template-pattern-begin:
+    - meta_scope: meta.string.template.regexp.ngx
+    - match: /
+      scope: punctuation.definition.pattern.begin.ngx
+      push: ng-template-pattern-body
+    - match: ''
+      fail: template-string
+
+  ng-template-pattern-body:
+    - match: (/)(\`)
+      captures:
+        1: punctuation.definition.pattern.end.ngx
+        2: string.quoted.other.ngx punctuation.definition.string.end.ngx
+      pop: 2
+    - match: (?=\`)
+      fail: template-string
+    - match: \n
+      scope: invalid.illegal.newline.ngx
+      pop: 2
+    - include: scope:source.regexp.embedded.ngx.template-string
+      apply_prototype: true
+
+  ng-template-plain-body:
+    - meta_scope: meta.string.template.ngx
+    - meta_content_scope: string.quoted.other.ngx
+    - match: \`
+      scope: string.quoted.other.ngx punctuation.definition.string.end.ngx
+      pop: 1
+    - match: \n
+      scope: invalid.illegal.newline.ngx
+      pop: 1
+    - include: ng-template-string-interpolations
+    - include: ng-string-content
+
+  ng-template-string-interpolations:
+    - match: \$\{
+      scope: punctuation.section.interpolation.begin.ngx
+      push: ng-template-string-interpolation-body
+
+  ng-template-string-interpolation-body:
+    - clear_scopes: 1
+    - meta_scope: meta.interpolation.ngx
+    - include: ng-template-text-interpolation-body
+
+  ng-template-text-interpolations:
+    # used by embedded syntaxes (e.g.: CSS or HTML)
+    - match: \$\{
+      scope: punctuation.section.interpolation.begin.ngx
+      push: ng-template-text-interpolation-body
+
+  ng-template-text-interpolation-body:
+    - meta_scope: meta.interpolation.ngx
+    - match: \}
+      scope: punctuation.section.interpolation.end.ngx
+      pop: 1
+    - include: ng-expressions
 
 ###[ ANGULAR VARIABLES ]#######################################################
 

--- a/NgxHTML.sublime-syntax
+++ b/NgxHTML.sublime-syntax
@@ -564,6 +564,8 @@ contexts:
     - match: \?(?!\.)
       scope: keyword.operator.ternary.ngx
       push: ng-ternary-expression
+    - match: in{{ident_break}}
+      scope: keyword.operator.comparison.ngx
     - match: (?:typeof|void){{ident_break}}
       scope: keyword.operator.type.ngx
 

--- a/tests/syntax_test_scopes.component.html
+++ b/tests/syntax_test_scopes.component.html
@@ -656,6 +656,11 @@
 <!--                       ^ punctuation.definition.string.end.ngx -->
 <!--                         ^^ punctuation.section.embedded.end.ngx.html -->
 
+  {{ "model" in cars }}
+<!-- ^^^^^^^ meta.string.ngx string.quoted.double.ngx -->
+<!--         ^^ keyword.operator.comparison.ngx -->
+<!--            ^^^^ variable.other.readwrite.ngx -->
+
   {{ type = typeof 32 }}
 <!-- ^^^^ variable.other.readwrite.ngx -->
 <!--      ^ keyword.operator.assignment.ngx -->

--- a/tests/syntax_test_scopes.component.html
+++ b/tests/syntax_test_scopes.component.html
@@ -655,6 +655,19 @@
 <!--                       ^ punctuation.definition.string.end.ngx -->
 <!--                         ^^ punctuation.section.embedded.end.ngx.html -->
 
+  {{ type = typeof 32 }}
+<!-- ^^^^ variable.other.readwrite.ngx -->
+<!--      ^ keyword.operator.assignment.ngx -->
+<!--        ^^^^^^ keyword.operator.type.ngx -->
+<!--               ^^ meta.number.integer.decimal.ngx constant.numeric.value.ngx -->
+
+
+  {{ type = void 32 }}
+<!-- ^^^^ variable.other.readwrite.ngx -->
+<!--      ^ keyword.operator.assignment.ngx -->
+<!--        ^^^^ keyword.operator.type.ngx -->
+<!--             ^^ meta.number.integer.decimal.ngx constant.numeric.value.ngx -->
+
   <!-- property subscription -->
   {{ person['name'][0] = "Mirabel" }}
 <!--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.expression.ngx.html -->

--- a/tests/syntax_test_scopes.component.html
+++ b/tests/syntax_test_scopes.component.html
@@ -513,6 +513,88 @@
 <!--          ^ punctuation.definition.string.begin.ngx -->
 <!--                ^ punctuation.definition.string.end.ngx -->
 
+  <!-- template strings -->
+  {{ `Hello ${name + `template ${var}`}` }}
+<!-- ^^^^^^^ meta.string.template.ngx - meta.interpolation -->
+<!--        ^^^^^^^^^ meta.string.template.ngx meta.interpolation.ngx - meta.string meta.string -->
+<!--                 ^^^^^^^^^^ meta.string.template.ngx meta.interpolation.ngx meta.string.template.ngx - meta.interpolation meta.interpolation -->
+<!--                           ^^^^^^ meta.string.template.ngx meta.interpolation.ngx meta.string.template.ngx meta.interpolation.ngx -->
+<!--                                 ^ meta.string.template.ngx meta.interpolation.ngx meta.string.template.ngx - meta.interpolation meta.interpolation -->
+<!--                                  ^ meta.string.template.ngx meta.interpolation.ngx - meta.string meta.string -->
+<!--                                   ^ meta.string.template.ngx - meta.interpolation -->
+<!-- ^^^^^^^ string.quoted.other.ngx -->
+<!--        ^^^^^^^^^ - string -->
+<!-- ^ punctuation.definition.string.begin.ngx -->
+<!--        ^^ punctuation.section.interpolation.begin.ngx -->
+<!--          ^^^^ variable.other.readwrite.ngx -->
+<!--               ^ keyword.operator.arithmetic.ngx -->
+<!--                 ^^^^^^^^^^ string.quoted.other.ngx -->
+<!--                 ^ punctuation.definition.string.begin.ngx -->
+<!--                           ^^^^^^ - string -->
+<!--                           ^^ punctuation.section.interpolation.begin.ngx -->
+<!--                             ^^^ variable.other.readwrite.ngx -->
+<!--                                ^ punctuation.section.interpolation.end.ngx -->
+<!--                                 ^ string.quoted.other.ngx punctuation.definition.string.end.ngx -->
+<!--                                  ^ punctuation.section.interpolation.end.ngx - string -->
+<!--                                   ^ string.quoted.other.ngx punctuation.definition.string.end.ngx -->
+
+  <!-- tagged template strings -->
+  {{ tag`Text \`${var}\`` }}
+<!-- ^^^ variable.function.tagged-template.ngx - string -->
+<!--    ^^^^^^^^^^^^^^^^^ meta.string.template.ngx -->
+<!--    ^^^^^^^^ string.quoted.other.ngx -->
+<!--    ^ punctuation.definition.string.begin.ngx -->
+<!--          ^^ constant.character.escape.ngx -->
+<!--            ^^^^^^ meta.interpolation.ngx - string -->
+<!--            ^^ punctuation.section.interpolation.begin.ngx -->
+<!--              ^^^ variable.other.readwrite.ngx -->
+<!--                 ^ punctuation.section.interpolation.end.ngx -->
+<!--                  ^^^ string.quoted.other.ngx -->
+<!--                  ^^ constant.character.escape.ngx -->
+<!--                    ^ punctuation.definition.string.end.ngx -->
+
+  <!-- regular expressions -->
+  {{ `/^[a-z]${var + `nest\`ed ${ `/\w+/` + pattern}`}\d+/` }}
+<!-- ^^^^^^^^ meta.string.template.regexp.ngx - meta.interpolation -->
+<!--         ^^^^^^^^ meta.string.template.regexp.ngx meta.interpolation.ngx - meta.string meta.strin -->
+<!--                 ^^^^^^^^^^ meta.string.template.regexp.ngx meta.interpolation.ngx meta.string.template.ngx - meta.interpolation meta.interpolation -->
+<!--                           ^^^ meta.string.template.regexp.ngx meta.interpolation.ngx meta.string.template.ngx meta.interpolation.ngx -->
+<!--                              ^^^^^^^ meta.string.template.regexp.ngx meta.interpolation.ngx meta.string.template.ngx meta.interpolation.ngx meta.string.template.regexp.ngx -->
+<!--                                     ^^^^^^^^^^^ meta.string.template.regexp.ngx meta.interpolation.ngx meta.string.template.ngx meta.interpolation.ngx -->
+<!--                                                ^ meta.string.template.regexp.ngx meta.interpolation.ngx meta.string.template.ngx - meta.interpolation meta.interpolation -->
+<!--                                                 ^ meta.string.template.regexp.ngx meta.interpolation.ngx - meta.string meta.strin -->
+<!--                                                  ^^^^^ meta.string.template.regexp.ngx - meta.interpolation -->
+<!-- ^ string.quoted.other.ngx punctuation.definition.string.begin.ngx -->
+<!--  ^ punctuation.definition.pattern.begin.ngx -->
+<!--   ^ keyword.control.anchor.regexp -->
+<!--    ^^^^^ meta.set.regexp -->
+<!--    ^ punctuation.definition.set.begin.regexp -->
+<!--     ^^^ constant.other.range.regexp -->
+<!--      ^ punctuation.separator.sequence.regexp -->
+<!--        ^ punctuation.definition.set.end.regexp -->
+<!--         ^^ punctuation.section.interpolation.begin.ngx -->
+<!--           ^^^ variable.other.readwrite.ngx -->
+<!--               ^ keyword.operator.arithmetic.ngx -->
+<!--                 ^^^^^^^^^^ string.quoted.other.ngx -->
+<!--                 ^ punctuation.definition.string.begin.ngx -->
+<!--                      ^^ constant.character.escape.ngx -->
+<!--                           ^^ punctuation.section.interpolation.begin.ngx -->
+<!--                              ^ string.quoted.other.ngx punctuation.definition.string.begin.ngx -->
+<!--                               ^ punctuation.definition.pattern.begin.ngx -->
+<!--                                ^^ keyword.control.character-class.regexp -->
+<!--                                  ^ keyword.operator.quantifier.regexp -->
+<!--                                   ^ punctuation.definition.pattern.end.ngx -->
+<!--                                    ^ string.quoted.other.ngx punctuation.definition.string.end.ngx -->
+<!--                                      ^ keyword.operator.arithmetic.ngx -->
+<!--                                        ^^^^^^^ variable.other.readwrite.ngx -->
+<!--                                               ^ punctuation.section.interpolation.end.ngx -->
+<!--                                                ^ string.quoted.other.ngx punctuation.definition.string.end.ngx -->
+<!--                                                 ^ punctuation.section.interpolation.end.ngx -->
+<!--                                                  ^^ keyword.control.character-class.regexp -->
+<!--                                                    ^ keyword.operator.quantifier.regexp -->
+<!--                                                     ^ punctuation.definition.pattern.end.ngx -->
+<!--                                                      ^ string.quoted.other.ngx punctuation.definition.string.end.ngx -->
+
   <!-- escaped chars -->
   {{ "\xAF \u2AFF \n \"" }}
 <!--^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.expression.ngx.html -->

--- a/tests/syntax_test_scopes.component.html
+++ b/tests/syntax_test_scopes.component.html
@@ -611,7 +611,7 @@
   https://angular.dev/guide/templates/expression-syntax#what-operators-are-supported
   -->
 
-  {{ - + * / % === !== == != = < <= >= > && || ! ?? }}
+  {{ - + * / % === !== == != = < <= >= > && || ! ?? ** }}
 <!-- ^ keyword.operator.arithmetic.ngx -->
 <!--   ^ keyword.operator.arithmetic.ngx -->
 <!--     ^ keyword.operator.arithmetic.ngx -->
@@ -630,6 +630,7 @@
 <!--                                        ^^ keyword.operator.logical.ngx -->
 <!--                                           ^ keyword.operator.logical.ngx -->
 <!--                                             ^^ keyword.operator.null-coalescing.ngx -->
+<!--                                                ^^ keyword.operator.arithmetic.ngx -->
 
   <!-- ternary -->
   {{ foo ? bar : baz }}


### PR DESCRIPTION
Resolves #36

This PR adds language features mentioned in #36.

Note: Tagged template strings don't include syntax highlighting at this point to maintain compatibility with ST4152.

Once this PR is merged and a ST4152 compatible release is made, another PR is prepared to add syntax highlighting and increase least required ST build to 4180.

The primary reason is we probably want to support both, properties and selectors, which requires CSS features, available with more recent ST builds only.

```
# properties
css`color: red`

# selectors
css`tag:first-child {color: red}`
```